### PR TITLE
fix(requirements): specify versions in requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,12 @@
 docutils==0.16
 Sphinx==3.3.1
-sphinx-copybutton
+sphinx-copybutton==0.3.0
+sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.4
+sphinxcontrib-qthelp==1.0.3
+alabaster==0.7.12
 furo==2020.10.5b9
-Jinja2
+Jinja2==2.10.1
+MarkupSafe==1.1.1


### PR DESCRIPTION
很多软件包有升级，不再支持manim中文文档所使用的Sphinx 3.3.1，提交中在docs/requirements.txt中把所使用到的一些组件的版本改为了发布于2020年及以前的旧版本

- sphinx-copybutton 0.3.0
- sphinxcontrib-applehelp 1.0.2
- sphinxcontrib-devhelp 1.0.2
- sphinxcontrib-htmlhelp 1.0.3
- sphinxcontrib-serializinghtml 1.1.4
- sphinxcontrib-qthelp 1.0.3
- alabaster 0.7.12
- Jinja2 2.10.1
- MarkupSafe 1.1.1